### PR TITLE
Fixed broken layout caused by non-closed tags for CSS Day talk

### DIFF
--- a/2016/cssday/index.html
+++ b/2016/cssday/index.html
@@ -127,7 +127,7 @@ color:#000;
 
 <section class="slide">
 <h2>Time for a nice cup of tea</h2>
-<img src="pictures/tea-and-pot.jpg" alt="Cup of tea"></section>
+<img src="pictures/tea-and-pot.jpg" alt="Cup of tea">
 </section>
 
 <section class="slide">
@@ -194,13 +194,13 @@ color:#000;
 
 <section class="slide">
 <h2>HTMl screen reader demo</h2>
-<video src="media/tequila-link.mp4">
+<video src="media/tequila-link.mp4"></video>
 </section>
 
 
 <section class="slide">
 <h2>HTML headings screen reader demo</h2>
-<video src="media/headings.mp4">
+<video src="media/headings.mp4"></video>
 </section>
 
 <section class="slide">
@@ -238,7 +238,7 @@ Generated content does not alter the document tree. In particular, it is not fed
 
 <section class="slide">
 <h2>:after screen reader demo</h2>
-<video src="media/tequila-link-after.mp4">
+<video src="media/tequila-link-after.mp4"></video>
 </section>
 
 <section class="slide">
@@ -287,7 +287,7 @@ Generated content does not alter the document tree. In particular, it is not fed
 
 <section class="slide">
 <h2>Keyboard demo</h2>
-<video src="media/no-flexbox.mp4">
+<video src="media/no-flexbox.mp4"></video>
 </section>
 
 <section class="slide">
@@ -298,18 +298,19 @@ Generated content does not alter the document tree. In particular, it is not fed
     &lt;button <mark>style="order: 2;"</mark>&gt;2&lt;/button&gt;
     &lt;button <mark>style="order: 1;"</mark>&gt;3&lt;/button&gt;
 &lt;/div&gt;
+</code></pre>
 </section>
 
 <section class="slide">
 <h2>Flexed keyboard demo</h2>
-<video src="media/flexbox-chrome.mp4">
+<video src="media/flexbox-chrome.mp4"></video>
 </section>
 
 <section class="slide">
 <h2>Spec advice?</h2>
 <blockquote cite="https://www.w3.org/TR/css-flexbox-1/#order-accessibility">
 Authors must use ‘order' only for visual, not logical, reordering of content.</blockquote>
- </section>
+</section>
 
  <section class="slide">
 <h2>tabindex attribute</h2>
@@ -324,7 +325,7 @@ Authors must use ‘order' only for visual, not logical, reordering of content.<
 
 <section class="slide">
 <h2>tabindex demo</h2>
-<video src="media/flexbox-firefox.mp4">
+<video src="media/flexbox-firefox.mp4"></video>
 </section>
 
 <section class="slide">
@@ -352,16 +353,17 @@ Authors must use ‘order' only for visual, not logical, reordering of content.<
     &lt;button <mark>id="b2" aria-flowto="b1"</mark> style="order: 2;"&gt;2&lt;/button&gt;
     &lt;button <mark>id="b3" aria-flowto="b2"</mark> style="order: 1;"&gt;3&lt;/button&gt;
 &lt;/div&gt;
+</code></pre>
 </section>
 
 <section class="slide">
 <h2>aria-flowto screen reader demo</h2>
-<video src="media/flexbox-aria-flowto.mp4">
+<video src="media/flexbox-aria-flowto.mp4"></video>
 </section>
 
 <section class="slide">
 <h2>The Firefox "bug"</h2>
-<video src="media/flexbox-firefox.mp4">
+<video src="media/flexbox-firefox.mp4"></video>
 </section>
 
 <section class="slide">
@@ -424,7 +426,7 @@ voice-pitch: medium;
 
 <section class="slide">
 <h2>Speech demo</h2>
-<video src="media/css-speech.mp4">
+<video src="media/css-speech.mp4"></video>
 </section>
 
 <section class="slide">
@@ -443,6 +445,6 @@ voice-pitch: medium;
 </section>
 
 <!--<div class="progress"></div> -->
-	<script src="shower/shower.min.js"></script>
-	</body>
-	</html>
+<script src="shower/shower.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
[There are 46 errors](https://validator.nu/?doc=http%3A%2F%2Fljwatson.github.io%2Fdecks%2F2016%2Fcssday%2Findex.html) in validator.nu because of that.
